### PR TITLE
Treat strings in PO files as interpreted rather than literals

### DIFF
--- a/gettext_test.go
+++ b/gettext_test.go
@@ -324,6 +324,17 @@ func (t *TestSuite) TestMessageCatalog_TryGettext_TranslationTypeAssertionFailed
 	t.Equal("", msgstr)
 }
 
+func (t *TestSuite) TestMessageCatalog_TryGettext_WithStringEscapes() {
+	mc, err := NewMessageCatalogFromString(`
+msgid "test\"with quotes\"\nand a newline"
+msgstr "This is a \"quoted\" string with a\nnewline."
+`)
+	t.NoError(err)
+	msgstr, err := mc.TryGettext("test\"with quotes\"\nand a newline")
+	t.NoError(err)
+	t.Equal("This is a \"quoted\" string with a\nnewline.", msgstr)
+}
+
 func (t *TestSuite) TestMessageCatalog_NGettext_Valid() {
 	msgid := "%d user likes this."
 	msgstr := t.mc.NGettext(msgid, "plural", 2)

--- a/po2json/po2json_test.go
+++ b/po2json/po2json_test.go
@@ -2,6 +2,7 @@ package po2json
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -128,6 +129,25 @@ msgstr ""
 ""
 `))
 	t.EqualError(err, "Encountered invalid state. Please ensure the input file is in a valid .po format.")
+}
+
+func (t *TestSuite) TestLoadBytes_EscapedQuotes() {
+	po, err := LoadBytes([]byte(`
+msgid "test"
+msgstr "This is a \"quoted\" string with a\nnewline."
+`))
+
+	t.NoError(err)
+	s, err := json.MarshalIndent(po, "", "    ")
+	t.NoError(err)
+	t.Equal(`{
+    "": {
+        "": {},
+        "test": {
+            "translation": "This is a \"quoted\" string with a\nnewline."
+        }
+    }
+}`, string(s))
 }
 
 func (t *TestSuite) TestLoadBytes_DuplicateMsgid() {

--- a/po2json/po2json_test.go
+++ b/po2json/po2json_test.go
@@ -2,7 +2,6 @@ package po2json
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -133,7 +132,7 @@ msgstr ""
 
 func (t *TestSuite) TestLoadBytes_EscapedQuotes() {
 	po, err := LoadBytes([]byte(`
-msgid "test"
+msgid "test\"with quotes\"\nand a newline"
 msgstr "This is a \"quoted\" string with a\nnewline."
 `))
 
@@ -143,7 +142,7 @@ msgstr "This is a \"quoted\" string with a\nnewline."
 	t.Equal(`{
     "": {
         "": {},
-        "test": {
+        "test\"with quotes\"\nand a newline": {
             "translation": "This is a \"quoted\" string with a\nnewline."
         }
     }


### PR DESCRIPTION
A bug existed that caused escaped characters in .po files to become even more escaped since they were treated as string literals instead of interpreted strings. 

Example:

```po
msgid "test"
msgstr "This is an \"escaped\" string\nwith a newline"
```

This would become

```json
{
    "": {
        "test": {
            "translation": "This is an \\\"escaped\\\" string\\nwith a newline"
        }
    }
}
```

Which, when printed, would look like the following: `This is an \"escaped\" string\nwith a newline`.

The expected result is:

```
This is an "escaped" string
with a newline
```

This PR corrects this problem by treating the strings in the .po file as interpreted strings rather than a string literal.