### PR TITLE
There should be no whitespace before comments or other specifiers

### DIFF
--- a/gettext_test.go
+++ b/gettext_test.go
@@ -31,6 +31,9 @@ var messagesJSON = []byte(`
                 "other"
             ]
         },
+		"#This is a message with a # sign.": {
+           "translation": "#This is a translation with a # sign."
+        },
         "One piggy went to the market.": {
             "translation": "Одна свинья ушла на рынок."
         }

--- a/gettext_test.go
+++ b/gettext_test.go
@@ -31,7 +31,7 @@ var messagesJSON = []byte(`
                 "other"
             ]
         },
-		"#This is a message with a # sign.": {
+        "#This is a message with a # sign.": {
            "translation": "#This is a translation with a # sign."
         },
         "One piggy went to the market.": {

--- a/po2json/po2json.go
+++ b/po2json/po2json.go
@@ -43,12 +43,12 @@ var (
 
 	regexComment        = regexp.MustCompile(`^#.*$`)
 	regexEmpty          = regexp.MustCompile(`^\s*$`)
-	regexMsgctxt        = regexp.MustCompile(`^msgctxt\s+(".*")`)
-	regexMsgid          = regexp.MustCompile(`^msgid\s+(".*")`)
-	regexMsgstr         = regexp.MustCompile(`^msgstr\s+(".*")`)
-	regexMsgidPlural    = regexp.MustCompile(`^msgid_plural\s+(".*")`)
-	regexMsgstrPlural   = regexp.MustCompile(`^msgstr\[\d+\]\s+(".*")`)
-	regexString         = regexp.MustCompile(`^(".*")`)
+	regexMsgctxt        = regexp.MustCompile(`^msgctxt\s+(".*")$`)
+	regexMsgid          = regexp.MustCompile(`^msgid\s+(".*")$`)
+	regexMsgstr         = regexp.MustCompile(`^msgstr\s+(".*")$`)
+	regexMsgidPlural    = regexp.MustCompile(`^msgid_plural\s+(".*")$`)
+	regexMsgstrPlural   = regexp.MustCompile(`^msgstr\[\d+\]\s+(".*")$`)
+	regexString         = regexp.MustCompile(`^(".*")$`)
 	regexHeaderKeyValue = regexp.MustCompile(`([a-zA-Z0-9-]+)\s*:\s*(.*?)(?:\n|\z)`)
 )
 

--- a/po2json/po2json.go
+++ b/po2json/po2json.go
@@ -41,14 +41,14 @@ var (
 		stateMsgstrPlural: "msgstr_plural",
 	}
 
-	regexComment        = regexp.MustCompile(`\s*#.*`)
+	regexComment        = regexp.MustCompile(`^#.*$`)
 	regexEmpty          = regexp.MustCompile(`^\s*$`)
-	regexMsgctxt        = regexp.MustCompile(`msgctxt\s+(".*")`)
-	regexMsgid          = regexp.MustCompile(`msgid\s+(".*")`)
-	regexMsgstr         = regexp.MustCompile(`msgstr\s+(".*")`)
-	regexMsgidPlural    = regexp.MustCompile(`msgid_plural\s+(".*")`)
-	regexMsgstrPlural   = regexp.MustCompile(`msgstr\[\d+\]\s+(".*")`)
-	regexString         = regexp.MustCompile(`(".*")`)
+	regexMsgctxt        = regexp.MustCompile(`^msgctxt\s+(".*")`)
+	regexMsgid          = regexp.MustCompile(`^msgid\s+(".*")`)
+	regexMsgstr         = regexp.MustCompile(`^msgstr\s+(".*")`)
+	regexMsgidPlural    = regexp.MustCompile(`^msgid_plural\s+(".*")`)
+	regexMsgstrPlural   = regexp.MustCompile(`^msgstr\[\d+\]\s+(".*")`)
+	regexString         = regexp.MustCompile(`^(".*")`)
 	regexHeaderKeyValue = regexp.MustCompile(`([a-zA-Z0-9-]+)\s*:\s*(.*?)(?:\n|\z)`)
 )
 

--- a/testdata/test.po
+++ b/testdata/test.po
@@ -35,6 +35,9 @@ msgctxt "Context with plural"
 msgid "One piggy went to the market."
 msgstr "Одна свинья ушла на рынок."
 
+msgid "#This is a message with a # sign."
+msgstr "#This is a translation with a # sign."
+
 #, fuzzy
 msgctxt ""
 "Context with plural"


### PR DESCRIPTION
Lines with `#` characters within a string resulted in the line being interpreted as a comment. This corrects the regexes to account for this.